### PR TITLE
[fix] 修复部分消息出现mention_*字段缺失问题

### DIFF
--- a/nonebot/adapters/kaiheila/message.py
+++ b/nonebot/adapters/kaiheila/message.py
@@ -905,12 +905,12 @@ class MessageDeserializer:
                 f"(rol){mention['role_id']}(rol)", f"@{mention['name']}"
             )
 
-        if self.data["mention_all"]:
+        if self.data.get("mention_all"):
             content_with_raw_mention = content_with_raw_mention.replace(
                 "(met)all(met)", "@全体成员"
             )
 
-        if self.data["mention_here"]:
+        if self.data.get("mention_here"):
             content_with_raw_mention = content_with_raw_mention.replace(
                 "(met)here(met)", "@在线成员"
             )
@@ -956,12 +956,12 @@ class MessageDeserializer:
                 lambda: MentionRole.create(mention["role_id"], mention["name"]),
             )
 
-        if self.data["mention_all"]:
+        if self.data.get("mention_all"):
             message = self.split_text(
                 message, "(met)all(met)", lambda: MentionAll.create()
             )
 
-        if self.data["mention_here"]:
+        if self.data.get("mention_here"):
             message = self.split_text(
                 message, "(met)here(met)", lambda: MentionHere.create()
             )


### PR DESCRIPTION
# 问题描述
当有用户加入服务器时，如果服务器内开启了欢迎消息，机器人接收到的欢迎消息会没有mention_all和mention_here字段
![image](https://github.com/Tian-que/nonebot-adapter-kaiheila/assets/54730982/956e50fc-5c42-4943-815e-753f8205c016)

# 问题复现
服务器开启欢迎通知，且有新用户加入服务器的时候

# 相关issue
#47 