### PR TITLE
[feat] 忽略处理其他bot的事件消息

### DIFF
--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -395,7 +395,9 @@ class Adapter(BaseAdapter):
             return
 
         # 屏蔽 Bot 自身和其他 Bot 的消息
-        if json_data["d"].get("author_id") == self_id or json_data['d'].get('extra', {}).get('author', {}).get('bot'):
+        if json_data["d"].get("author_id") == self_id or json_data["d"].get(
+            "extra", {}
+        ).get("author", {}).get("bot"):
             return
 
         try:

--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -394,8 +394,8 @@ class Adapter(BaseAdapter):
             # 不存在的signal，resume是不可能resume的，这辈子都不会resume的，出了问题直接重连
             return
 
-        # 屏蔽 Bot 自身的消息
-        if json_data["d"].get("author_id") == self_id:
+        # 屏蔽 Bot 自身和其他 Bot 的消息
+        if json_data["d"].get("author_id") == self_id or json_data['d'].get('extra', {}).get('author', {}).get('bot'):
             return
 
         try:


### PR DESCRIPTION
# 问题描述
按照原代码，机器人只会忽略自身的事件消息，之前kook官方好像给事件加入了是否为bot上报事件的标识字段