### PR TITLE
[feat] 支持忽略处理某些事件

### DIFF
--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -443,9 +443,9 @@ class Adapter(BaseAdapter):
             sub_type = data.get("sub_type")
             sub_type = f".{sub_type}" if sub_type else ""
 
-            event_name = post_type + detail_type + sub_type
+            event_name: str = post_type + detail_type + sub_type
             if ignore_events and any(
-                ignore_event in event_name for ignore_event in ignore_events
+                event_name.startswith(ignore_event) for ignore_event in ignore_events
             ):
                 return
 

--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -4,7 +4,7 @@ import zlib
 import asyncio
 import inspect
 from typing_extensions import override
-from typing import Any, Dict, List, Type, Union, Mapping, Callable, Optional
+from typing import Any, Dict, List, Tuple, Type, Union, Mapping, Callable, Optional
 
 from pygtrie import StringTrie
 from pydantic import parse_obj_as
@@ -365,7 +365,7 @@ class Adapter(BaseAdapter):
         json_data: Any,
         self_id: Optional[str] = None,
         *,
-        ignore_events: Optional[List[str]] = None,
+        ignore_events: Optional[Tuple[str, ...]] = None,
     ) -> Union[OriginEvent, Event, None]:
         if not isinstance(json_data, dict):
             return None
@@ -444,9 +444,7 @@ class Adapter(BaseAdapter):
             sub_type = f".{sub_type}" if sub_type else ""
 
             event_name: str = post_type + detail_type + sub_type
-            if ignore_events and any(
-                event_name.startswith(ignore_event) for ignore_event in ignore_events
-            ):
+            if ignore_events and event_name.startswith(ignore_events):
                 return
 
             models = cls.get_event_model(event_name)

--- a/nonebot/adapters/kaiheila/config.py
+++ b/nonebot/adapters/kaiheila/config.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from pydantic import Field, BaseModel
 
@@ -35,7 +35,7 @@ class Config(BaseModel):
 
     kaiheila_bots: List["BotConfig"] = Field(default_factory=list)
     compress: Optional[bool] = Field(default=False)
-    kaiheila_ignore_events: List[str] = Field(default_factory=list)
+    kaiheila_ignore_events: Tuple[str, ...] = Field(default_factory=tuple)
 
     class Config:
         extra = "allow"

--- a/nonebot/adapters/kaiheila/config.py
+++ b/nonebot/adapters/kaiheila/config.py
@@ -35,6 +35,7 @@ class Config(BaseModel):
 
     kaiheila_bots: List["BotConfig"] = Field(default_factory=list)
     compress: Optional[bool] = Field(default=False)
+    kaiheila_ignore_events: List[str] = Field(default_factory=list)
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
# 需求描述
Bot如果加入了一些人数较多的服务器会经常收到来自kook服务端推送的一些notice事件
比如我的小日向Bot，一分钟可能会收到50多条成员上下线的通知，所以也就有了忽略处理某些事件的需求
既然不能在kook服务端配置接收哪些event，那只能在客户端这边配置了
![image](https://github.com/Tian-que/nonebot-adapter-kaiheila/assets/54730982/4b193f17-9a2e-4956-848d-54178b1e7f8f)

# 使用说明
配置文件内加入`KAIHEILA_IGNORE_EVENTS='[ ]'`，里面可以填写多个event_name
- `notice.guild_member_online`  忽略成员上线通知事件
- `notice.guild_member_` 忽略成员上线/下线通知事件
-  `notice.`  忽略所有通知事件

# 相关issue
#48 