### PR TITLE
feat: 为屏蔽其他Bot消息添加配置项开关

### DIFF
--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -401,12 +401,12 @@ class Adapter(BaseAdapter):
             # 不存在的signal，resume是不可能resume的，这辈子都不会resume的，出了问题直接重连
             return
 
-        # 屏蔽 Bot 自身和其他 Bot 的消息
-        if json_data["d"].get("author_id") == self_id or json_data["d"].get(
-            "extra", {}
-        ).get("author", {}).get("bot"):
+        # 屏蔽 Bot 自身
+        if json_data["d"].get("author_id") == self_id :
             return
-
+        # 屏蔽其他Bot消息
+        if json_data["d"].get("extra", {}).get("author", {}).get("bot") and cls.kaiheila_config.kaiheila_ignore_else_bots:
+            return
         try:
             data = json_data["d"]
             extra = data.get("extra")

--- a/nonebot/adapters/kaiheila/config.py
+++ b/nonebot/adapters/kaiheila/config.py
@@ -44,6 +44,7 @@ class Config(BaseModel):
     kaiheila_bots: List["BotConfig"] = Field(default_factory=list)
     compress: Optional[bool] = Field(default=False)
     kaiheila_ignore_events: Tuple[str, ...] = Field(default_factory=tuple)
+    kaiheila_ignore_else_bots: Optional[bool] = Field(default=True)
 
     if PYDANTIC_V2:
         model_config = ConfigDict(

--- a/nonebot/adapters/kaiheila/config.py
+++ b/nonebot/adapters/kaiheila/config.py
@@ -44,7 +44,7 @@ class Config(BaseModel):
     kaiheila_bots: List["BotConfig"] = Field(default_factory=list)
     compress: Optional[bool] = Field(default=False)
     kaiheila_ignore_events: Tuple[str, ...] = Field(default_factory=tuple)
-    kaiheila_ignore_else_bots: Optional[bool] = Field(default=True)
+    kaiheila_ignore_other_bots: Optional[bool] = Field(default=True)
 
     if PYDANTIC_V2:
         model_config = ConfigDict(


### PR DESCRIPTION
为屏蔽其他Bot消息添加配置项开关，该配置项默认启用
部分场景下，还是需要多个bot间传递消息实现数据同步的