### PR TITLE
fix: 修复log输出时未对<>进行转义问题

### DIFF
--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -459,7 +459,7 @@ class Adapter(BaseAdapter):
                     log("DEBUG", "Event Parser Error", e)
             else:
                 event = type_validate_python(Event, json_data)
-            log("DEBUG", str(model_dump(event)))
+            log("DEBUG", str(model_dump(event)).replace("<","\<"))
             return event
         except Exception as e:
             log(


### PR DESCRIPTION
# 问题描述
`str(model_dump(event)))`的文本会包含用户的id和子频道的名称，当上述两者出现`< >`文本时会被loguru认为是颜色代码

```
02-25 19:18:57 [ERROR] nonebot | Kaiheila | Failed to parse event. Raw: { ... }
Traceback (most recent call last):
...
...
...
  File "d:\xrx\xrx-bot\.venv\Lib\site-packages\nonebot\adapters\kaiheila\adapter.py", line 261, in _forward_ws
    event = self.json_to_event(
> File "d:\xrx\xrx-bot\.venv\Lib\site-packages\nonebot\adapters\kaiheila\adapter.py", line 462, in json_to_event
    log("DEBUG", str(model_dump(event)))
  File "d:\xrx\xrx-bot\.venv\Lib\site-packages\nonebot\utils.py", line 323, in log
    logger.opt(colors=True, exception=exception).log(
  File "d:\xrx\xrx-bot\.venv\Lib\site-packages\loguru\_colorizer.py", line 368, in prepare_simple_message
    parser.feed(string)
  File "d:\xrx\xrx-bot\.venv\Lib\site-packages\loguru\_colorizer.py", line 252, in feed
    raise ValueError(
ValueError: Tag "<8>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)
```
![image](https://github.com/Tian-que/nonebot-adapter-kaiheila/assets/54730982/2e2855d6-93a7-414b-9ead-5560fef19009)

# 解决办法
日志输出时将`<`替换为`\<`
![image](https://github.com/Tian-que/nonebot-adapter-kaiheila/assets/54730982/29fb05a0-26d9-48ca-9b77-7cb450dbb44e)
