### PR TITLE
[fix] resume reset sn

### DIFF
--- a/nonebot/adapters/kaiheila/adapter.py
+++ b/nonebot/adapters/kaiheila/adapter.py
@@ -255,6 +255,7 @@ class Adapter(BaseAdapter):
                 if bot_config.token:
                     headers["Authorization"] = f"Bot {bot_config.token}"
                 request = Request("GET", URL(url), headers=headers)
+                log("INFO", f"Connecting to {escape_tag(str(url))}")
                 async with self.websocket(request) as ws:
                     log(
                         "DEBUG",
@@ -306,10 +307,11 @@ class Adapter(BaseAdapter):
                     except ReconnectError as e:
                         log(
                             "ERROR",
-                            "<r><bg #f8bbd0>Server requests reconnect"
+                            "<r><bg #f8bbd0>Server requests reconnect "
                             f"{'for bot ' + escape_tag(bot.self_id) if bot else ''}, {e}</bg #f8bbd0></r>",
                         )
                         need_reconnect = False
+                        ResultStore.set_sn(bot.self_id, 0)
                     except TokenError as e:
                         log(
                             "ERROR",
@@ -317,7 +319,9 @@ class Adapter(BaseAdapter):
                             f"{'for bot ' + escape_tag(bot.self_id) if bot else ''}, {e}</bg #f8bbd0></r>",
                         )
                         need_reconnect = False
+                        ResultStore.set_sn(bot.self_id, 0)
                     except Exception as e:
+                        # 非预期异常，需要重连，不重置sn
                         log(
                             "ERROR",
                             "<r><bg #f8bbd0>Error while process data from websocket"


### PR DESCRIPTION
在服务端下发信令`reconnect`后，客户端应该清空本地sn计数
否则在后续新建连接时，本地ping的心跳包里携带的sn如果不是0则会导致服务端无限下发重连信令

![image](https://github.com/user-attachments/assets/d931651e-63d0-40e5-b773-8f5c2174b423)
